### PR TITLE
Add quotation marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A very small Clojure library for assembling JAR files. Quite usable, but doesn't
 do much.
 
-Leiningen dependency: `[org.clj-grimoire/darkestperu 1.0.0-rc.2]`
+Leiningen dependency: `[org.clj-grimoire/darkestperu "1.0.0-rc.2"]`
 
 [API docs](https://clj-grenada.github.io/darkestperu/api-docs) (with backlink!)
 


### PR DESCRIPTION
So that users can copy/paste the version string.
The canonical fix here is to use a clojars svg, but that has its failings.

Fixed up from #1 
